### PR TITLE
Replaced CI_COMMIT_REF_SLUG with CI_COMMIT_SHORT_SHA 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,20 +10,20 @@ build container:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
     - |
       # Build if not yet present in registry
-      if ! docker pull "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" > /dev/null 2>&1; then
-        docker build --pull --build-arg MMD_AGENT_VERSION=$mmd_agent_version -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" container
-        docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG"
+      if ! docker pull "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" > /dev/null 2>&1; then
+        docker build --pull --build-arg MMD_AGENT_VERSION=$mmd_agent_version -t "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" container
+        docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA"
       fi
     - |
       # Default branch updates latest container image
       if [[ "$CI_COMMIT_BRANCH" == "$CI_DEFAULT_BRANCH" ]]; then
-        docker tag "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" "$CI_REGISTRY_IMAGE:latest"
+        docker tag "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" "$CI_REGISTRY_IMAGE:latest"
         docker push "$CI_REGISTRY_IMAGE:latest"
       fi
     - |
       # Tags also creates container image tags as references to the same build
       if [[ "$CI_COMMIT_TAG" != "" ]]; then
-        docker tag "$CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG" "$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG"
+        docker tag "$CI_REGISTRY_IMAGE:$CI_COMMIT_SHORT_SHA" "$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG"
         docker push "$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG"
       fi
   tags:
@@ -40,5 +40,5 @@ tjenester/s-enda:
     UPSTREAM_CI_COMMIT_SHA: "${CI_COMMIT_SHA}"
     UPSTREAM_CI_PROJECT_PATH: "${CI_PROJECT_PATH}"
     UPSTREAM_CI_PROJECT_URL: "${CI_PROJECT_URL}"
-    UPSTREAM_IMAGES: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_REF_SLUG}"
+    UPSTREAM_IMAGES: "${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA}"
   trigger: tjenester/s-enda


### PR DESCRIPTION
Replaced `CI_COMMIT_REF_SLUG` with `CI_COMMIT_SHORT_SHA` for building docker image