### PR TITLE
Handle not to proceed to deployment if build fails.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,12 +32,9 @@ build container:
 
 tjenester/s-enda:
   stage: release
-  needs:
-    - job: build container
-      artifacts: true
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      when: always
+      when: on_success
     - when: never
   variables:
     UPSTREAM_CI_COMMIT_SHA: "${CI_COMMIT_SHA}"


### PR DESCRIPTION
Replace rule 'when:always' to 'when:on_success'
-remove need keyword